### PR TITLE
Add an OTA demo demonstrating how to use the PSA based OTA PAL

### DIFF
--- a/vendors/arm/boards/musca_b1/aws_demos/application_code/ReadMe.txt
+++ b/vendors/arm/boards/musca_b1/aws_demos/application_code/ReadMe.txt
@@ -1,0 +1,44 @@
+This demo is a work based on:
+    1. Amazon FreeRTOS
+       commit: 5251eeaf0
+    2. TF-M (Trusted Firmware M) - https://git.trustedfirmware.org/trusted-firmware-m.git/)
+       commit: b1637d53d
+
+Introduction of the demo:
+    1. Get the application version via the PSA Firmware Update service
+    2. Provision the credentials for the TLS connection
+    3. Provision the public key for image verification in OTA
+    4. Turn on wifi and connect to the access point as a station
+    5. Run the OTA demo provided by Amazon FreeRTOS
+
+How to build:
+    This project is a Keil project. We use the Keil IDE to build it.
+    1. Build TF-M for Musca B1 platform
+       a. cd trusted-firmware-m
+       b. build for Library mode:
+          cmake -S ./ -B build -DTFM_PLATFORM=musca_b1/sse_200 -DMCUBOOT_IMAGE_NUMBER=1 -DMCUBOOT_HW_KEY=OFF -D CMAKE_BUILD_TYPE=Debug -D TFM_NS_CLIENT_IDENTIFICATION=OFF -DMCUBOOT_SIGNATURE_TYPE=RSA -DITS_MAX_ASSET_SIZE=1300 -DPS_RAM_FS=ON -DMCUBOOT_SIGNATURE_KEY_LEN=2048 -DCRYPTO_HW_ACCELERATOR=OFF  -DCRYPTO_ENGINE_BUF_SIZE=0x8000
+          build for IPC mode:
+          cmake -S ./ -B build -DTFM_PLATFORM=musca_b1/sse_200 -DMCUBOOT_IMAGE_NUMBER=1 -DMCUBOOT_HW_KEY=OFF -D CMAKE_BUILD_TYPE=Debug -D TFM_NS_CLIENT_IDENTIFICATION=OFF -DMCUBOOT_SIGNATURE_TYPE=RSA -DITS_MAX_ASSET_SIZE=1300 -DPS_RAM_FS=ON -DMCUBOOT_SIGNATURE_KEY_LEN=2048 -DCRYPTO_HW_ACCELERATOR=OFF  -DCRYPTO_ENGINE_BUF_SIZE=0x8000 -DTFM_PSA_API=ON
+       e. cmake --build ./ -- install
+       You can find detailed instructions from:
+       https://git.trustedfirmware.org/trusted-firmware-m.git/tree/docs/user_guides/tfm_build_instruction.rst
+    4. Build the demo
+       Open the Keil project of the demo and build. Note that two configurable targets are contained in the project: Library mode(by default) and IPC mode.s
+       The default build is for TF-M Library mode.
+       If you want to build for IPC mode:
+           a. Build TFM in IPC mode.
+           b. Select target as IPC mode.
+           c. Rebuild the demo.
+       If you want to build for Library mode:
+           a. Build TFM in Library mode.
+           b. Select target as Library mode.
+           c. Rebuild the demo.
+       In both modes, the output image is rtos_tfm_MUSCA_B1.hex.
+
+
+How to run the demo on Arm Musca-B1 board:
+    Download the image(rtos_tfm_MUSCA_B1.hex) to Musca-B1 board following the
+    "Execute TF-M example and regression tests on Musca test chip boards" section
+    in https://git.trustedfirmware.org/trusted-firmware-m.git/tree/docs/user_guides/tfm_user_guide.rst.
+
+*Copyright (c) 2019-2021, Arm Limited. All rights reserved.*

--- a/vendors/arm/boards/musca_b1/aws_demos/application_code/main.c
+++ b/vendors/arm/boards/musca_b1/aws_demos/application_code/main.c
@@ -1,0 +1,255 @@
+/*
+ * FreeRTOS Kernel V10.2.1
+ * Copyright (C) 2019 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ * Copyright (c) 2019-2021 Arm Limited. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * http://www.FreeRTOS.org
+ * http://aws.amazon.com/freertos
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/*
+ * This file is derivative of FreeRTOS V10.2.1
+ * demo\CORTEX_MPU_M33F_Simulator_Keil_GCC\NonSecure\main_ns.c
+ */
+
+#include <string.h>
+
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Arm Musca_b1 platform log print. */
+#include "print_log.h"
+
+/* Logging task. */
+#include "iot_logging_task.h"
+
+/* Arm Musca_b1 platform hardware setup. */
+#include "hardware_setup.h"
+
+/* TF-M platform service. */
+#include "musca_b1_scc_drv.h"
+#include "tfm_ioctl_api.h"
+
+/* Wifi and secure socket libray. */
+#include "iot_wifi.h"
+#include "esp/esp_private.h"
+#include "iot_secure_sockets.h"
+
+/* Credentials and their provisioning. */
+#include "aws_clientcredential.h"
+#include "aws_dev_mode_key_provisioning.h"
+
+/* TF-M Firmware Update service. */
+#include "psa/update.h"
+
+/* Application version. */
+#include "application_version.h"
+#include "aws_demo.h"
+
+/* TF-M Crypto service. */
+#include "psa/crypto.h"
+
+/* Code verify key provisioning. */
+#include "ota_provision.h"
+#include "tfm_ns_interface.h"
+
+#define mainLOGGING_TASK_STACK_SIZE ( configMINIMAL_STACK_SIZE * 8 )
+#define mainLOGGING_MESSAGE_QUEUE_LENGTH ( 20 )
+#define wifiCONNECTION_DELAY    pdMS_TO_TICKS( 1000 )
+
+extern uint32_t Image$$ER_IROM_NS_PRIVILEGED$$Base;
+extern uint32_t Image$$ER_IROM_NS_FREERTOS_SYSTEM_CALLS$$Base;
+extern uint32_t Image$$ER_IROM_NS_UNPRIVILEGED$$Base;
+extern uint32_t Image$$ER_IRAM_NS_PRIVILEGED$$Base;
+extern uint32_t Image$$ER_IRAM_NS_TASKS_SHARE$$Base;
+
+extern uint32_t Image$$IROM_NS_PRIVILEGED_ALIGN$$Limit;
+extern uint32_t Image$$IROM_NS_FREERTOS_ALIGN$$Limit;
+extern uint32_t Image$$IROM_NS_UNPRIVILEGED_ALIGN$$Limit;
+extern uint32_t Image$$IRAM_NS_PRIVILEGED_ALIGN$$Limit;
+extern uint32_t Image$$IRAM_NS_TASKS_SHARE_ALIGN$$Limit;
+
+/* Externs needed by the MPU setup code. These must match the memory map as
+ * specified in Scatter-Loading description file (musca_ns.sct). */
+/* Privileged flash. */
+const uint32_t * __privileged_functions_start__    = ( uint32_t * ) &( Image$$ER_IROM_NS_PRIVILEGED$$Base );
+const uint32_t * __privileged_functions_end__    = ( uint32_t * ) (( uint32_t )&( Image$$IROM_NS_PRIVILEGED_ALIGN$$Limit ) - 0x1 );  /* Last address in privileged Flash region. */
+
+/* Flash containing system calls. */
+const uint32_t * __syscalls_flash_start__    = ( uint32_t * ) &( Image$$ER_IROM_NS_FREERTOS_SYSTEM_CALLS$$Base );
+const uint32_t * __syscalls_flash_end__        = ( uint32_t * ) (( uint32_t )&( Image$$IROM_NS_FREERTOS_ALIGN$$Limit ) - 0x1 );  /* Last address in Flash region containing system calls. */
+
+/* Unprivileged flash. Note that the section containing
+ * system calls is unprivilged so that unprivleged tasks
+ * can make system calls. */
+const uint32_t * __unprivileged_flash_start__    = ( uint32_t * ) &( Image$$ER_IROM_NS_UNPRIVILEGED$$Base );
+const uint32_t * __unprivileged_flash_end__    = ( uint32_t * ) (( uint32_t )&( Image$$IROM_NS_UNPRIVILEGED_ALIGN$$Limit ) - 0x1 );  /* Last address in un-privileged Flash region. */
+
+/* Priviledge ram. This contains kernel data. */
+const uint32_t * __privileged_sram_start__    = ( uint32_t * ) &( Image$$ER_IRAM_NS_PRIVILEGED$$Base );
+const uint32_t * __privileged_sram_end__    = ( uint32_t * ) (( uint32_t )&( Image$$IRAM_NS_PRIVILEGED_ALIGN$$Limit ) - 0x1 ); /* Last address in privileged RAM. */
+
+/* The key for OTA code verification. */
+psa_key_handle_t ota_code_verify_key_handle = NULL;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Creates all the tasks for this demo.
+ */
+static void prvCreateTasks( void );
+
+/* Non-secure main() */
+int main( void )
+{
+BaseType_t xRet;
+    xRet = xHardwareSetup();
+    configASSERT( xRet == pdPASS );
+
+    /* Initialise the UART lock. */
+    vUARTLockInit();
+
+    /* Initialize the secure interface lock */
+    tfm_ns_interface_init();
+
+    /* Create tasks. */
+    prvCreateTasks();
+
+    /* Start the scheduler. */
+    vTaskStartScheduler();
+
+    /* Should not reach here as the scheduler is already started. */
+    for( ; ; )
+    {
+    }
+}
+/*-----------------------------------------------------------*/
+
+static void prvCreateTasks( void )
+{
+    xLoggingTaskInitialize( mainLOGGING_TASK_STACK_SIZE,
+                            (tskIDLE_PRIORITY + 2) | portPRIVILEGE_BIT,
+                            mainLOGGING_MESSAGE_QUEUE_LENGTH );
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationDaemonTaskStartupHook( void )
+{
+enum tfm_platform_err_t xErr;
+uint32_t ulReqResult;
+WIFIReturnCode_t xWifiStatus;
+WIFINetworkParams_t xNetworkParams;
+BaseType_t xResult = pdPASS;
+
+xNetworkParams.xSecurity = clientcredentialWIFI_SECURITY;
+
+xNetworkParams.ucSSIDLength = strlen( clientcredentialWIFI_SSID );
+memcpy( xNetworkParams.ucSSID, clientcredentialWIFI_SSID, xNetworkParams.ucSSIDLength );
+
+xNetworkParams.xPassword.xWPA.ucLength = strlen( clientcredentialWIFI_PASSWORD );
+memcpy( xNetworkParams.xPassword.xWPA.cPassphrase, clientcredentialWIFI_PASSWORD, xNetworkParams.xPassword.xWPA.ucLength );
+
+    /* This task calls secure side functions. So allocate a
+     * secure context for it. */
+    portALLOCATE_SECURE_CONTEXT( 0 );
+
+    /* This demo is to update the Non-Secure image. */
+    configASSERT( GetImageVersionPSA(FWU_IMAGE_TYPE_NONSECURE) == 0 )
+
+    /* TODO: currently the ns_lock mutex only support calling TF-M
+     * services in the task. Move the GPIO set to the hardwaresetup
+     * after this restriction is removed.
+     */
+    /* set GPIO 0 & 1 as UART */
+    xErr = tfm_platform_set_pin_alt_func( 1, 0b11, &ulReqResult );
+    if( xErr != TFM_PLATFORM_ERR_SUCCESS )
+    {
+        xResult = pdFAIL;
+    }
+    configASSERT( xResult == pdPASS );
+
+    /* Provision the credentials for TLS connection. */
+    vDevModeKeyProvisioning();
+
+    /* Provision the key which is used to verify the image in OTA. */
+    xResult = ota_provision_code_verify_key( &ota_code_verify_key_handle );
+    configASSERT( xResult == 0 );
+
+    /* Turn on wifi and connect to the access point as a station. */
+    xWifiStatus = WIFI_On();
+    configASSERT( xWifiStatus == eWiFiSuccess );
+    xWifiStatus = WIFI_ConnectAP( &xNetworkParams );
+    if( xWifiStatus != eWiFiSuccess )
+    {
+        print_log( "WIFI_ConnectAP failed" );
+    }
+
+    /* The AT command is sent by the uart task which has a low priority
+     * than this task, so delay some time to yield.
+      */
+    vTaskDelay( wifiCONNECTION_DELAY );
+
+    /* Disable sleep mode so that the wifi connect can keep alive
+     * during the TLS connect process. This is to avoid the bug in
+     * ESP8266.
+     */
+    ESP_AT_PORT_SEND_BEGIN();
+    ESP_AT_PORT_SEND_STR( "+SLEEP=0" );
+    ESP_AT_PORT_SEND_END();
+    vTaskDelay( wifiCONNECTION_DELAY );
+
+    SOCKETS_Init();
+
+    /* Run the demo. Only the OTA demo is enabled in the configuration. */
+    DEMO_RUNNER_RunDemos();
+}
+/*-----------------------------------------------------------*/
+
+void prvMemManageDebug( void )
+{
+    for( ; ; )
+    {
+    }
+}
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The fault handler implementation calls a function called
+ * prvGetRegistersFromStack().
+ */
+void MemManage_Handler( void )
+{
+    __asm volatile
+    (
+        " tst lr, #4                                                \n"
+        " ite eq                                                    \n"
+        " mrseq r0, msp                                             \n"
+        " mrsne r0, psp                                             \n"
+        " ldr r1, handler2_address_const                            \n"
+        " bx r1                                                     \n"
+        "                                                           \n"
+        " .align 2                                                    \n"
+        " handler2_address_const: .word prvMemManageDebug           \n"
+    );
+}
+/*-----------------------------------------------------------*/

--- a/vendors/arm/boards/musca_b1/aws_demos/provision/ota_provision.c
+++ b/vendors/arm/boards/musca_b1/aws_demos/provision/ota_provision.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+/* Key provisioning include. */
+#include "ota_provision.h"
+
+/* The variable cOTARSAPublicKey contains the public key which is used to verify
+ * the image in an OTA process.
+ *
+ * The value assigned here is the public key which is derivated from
+ * ./bl2/ext/mcuboot/root-rsa-2048_1.pem in TF-M repo.
+ * #######  DO NOT USE THIS KEY IN PRODUCTION #######
+ *
+ * Please note that the OTA service only support RSA2048(RSA3072
+ * is not supported) currently.
+ */
+static const char cOTARSAPublicKey[] =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArNJ0kz5f56/yyGzoWFFj\n"
+    "dw5S/ljVu6XjnIrNFAqJxhWuSQSfXz0riRIfPn8F/AuZJmNelu8zvIwnaE1GjWYz\n"
+    "mTs4ERvjrBgHlUiHsqtPLQ4SURt/M7p4sdX6f79xS+RfZ1dn1au7ZAYXPYHr2MH5\n"
+    "elfTKVwQ/6fTOlg/JYrFhHuXJ6XkkOffHDPmfK9od14fCW7dkmBOrHOEsPe2AsLO\n"
+    "n6+tsrFXzPkGHWolL3Iqff4N7bjClYhB8kWobmqF7q76inn6/n5ASUPsLI6Ogn7i\n"
+    "+A/y6X2jf6wjvQpC6hj7cqCaJAHIJ4xWJJOC3yMZlnPyEcMF5qW4C+BzzgebV+aO\n"
+    "+wIDAQAB\n"
+    "-----END PUBLIC KEY-----";
+
+/* This function can be found in libraries/3rdparty/mbedtls_utils/mbedtls_utils.c. */
+extern int convert_pem_to_der( const unsigned char * pucInput,
+                               size_t xLen,
+                               unsigned char * pucOutput,
+                               size_t * pxOlen );
+
+int ota_provision_code_verify_key( psa_key_handle_t * key_handle )
+{
+uint8_t public_key_der[310];
+size_t xLength = 310;
+int result;
+psa_key_handle_t key_handle_tmp = NULL;
+psa_status_t status;
+psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+    result = convert_pem_to_der( ( const unsigned char * ) cOTARSAPublicKey,
+                                sizeof( cOTARSAPublicKey ),
+                                public_key_der,
+                                &xLength );
+    if( result != 0 )
+    {
+        return result;
+    }
+
+    psa_set_key_usage_flags( &attributes, PSA_KEY_USAGE_VERIFY_HASH );
+    psa_set_key_algorithm( &attributes, PSA_ALG_RSA_PSS( PSA_ALG_SHA_256 ) );
+    psa_set_key_type( &attributes, PSA_KEY_TYPE_RSA_PUBLIC_KEY );
+    psa_set_key_bits( &attributes, 2048 );
+    status = psa_import_key( &attributes,
+                            ( const uint8_t *)public_key_der,
+                            xLength,
+                            &key_handle_tmp );
+
+    if( status == PSA_SUCCESS )
+    {
+        *key_handle = key_handle_tmp;
+    }
+    return status;
+}
+/*-----------------------------------------------------------*/

--- a/vendors/arm/boards/musca_b1/aws_demos/provision/ota_provision.h
+++ b/vendors/arm/boards/musca_b1/aws_demos/provision/ota_provision.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020-2021 Arm Limited. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef _OTA_PROVISION_
+#define _OTA_PROVISION_
+#include "psa/crypto.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int ota_provision_code_verify_key(psa_key_handle_t * key_handle);
+
+#ifdef __cplusplus
+}
+#endif
+#endif


### PR DESCRIPTION
Signed-off-by: Sherry Zhang <sherry.zhang2@arm.com>
Change-Id: I36ab7e5ac5861954107e8a49233ed44f356b5fcc

The demo uses the PSA based OTA PAL implementation in[ this PR](https://github.com/Linaro/amazon-freertos/pull/5). The target board is
the Arm Musca_b1 platform. This commit only includes the logically related
code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.